### PR TITLE
Gl crash fix and interface updates

### DIFF
--- a/src/txt/TextBox.h
+++ b/src/txt/TextBox.h
@@ -29,9 +29,10 @@ namespace txt
 			TextBox& layoutIfNeeded();
 			TextBox& doLayout();
 
-			Layout& getLayout() { return mLayout; };
+			Layout& getLayout()				{ return mLayout; };
+			const Layout& getLayout() const { return mLayout; };
 
-			RendererRef getRenderer() { return mRenderer; }
+			RendererRef getRenderer() const { return mRenderer; }
 			void setRenderer( RendererRef renderer ) { mRenderer = renderer; }
 
 			void draw();

--- a/src/txt/TextBox.h
+++ b/src/txt/TextBox.h
@@ -16,8 +16,12 @@ namespace txt
 			ci::ivec2 getSize();
 			TextBox& setSize( ci::vec2 size );
 
+			const Font&	getFont() const	{ return mFont; }
 			TextBox& setFont( const Font& font );
+
+			const std::string&	getText() const	{ return mText; }
 			TextBox& setText( std::string text );
+
 			TextBox& setAttrString( AttributedString attrString );
 			TextBox& setColor( ci::ColorA color );
 			TextBox& setAlignment( Alignment alignment );

--- a/src/txt/TextLayout.cpp
+++ b/src/txt/TextLayout.cpp
@@ -383,7 +383,7 @@ namespace txt
 		mCharPos = 0.f;
 		mLinePos += mCurLineHeight;
 
-		mCurLineHeight = mLineHeight.getValue( mFont.getSize() );
+		mCurLineHeight = ! mLineHeight.isDefault() ? mLineHeight.getValue( mFont.getSize() ) : mFont.getLineHeight();
 		mCurLineWidth = 0;
 	}
 

--- a/src/txt/TextLayout.h
+++ b/src/txt/TextLayout.h
@@ -71,34 +71,34 @@ namespace txt
 			std::vector<Line>& getLines() { return mLines; };
 
 			// Layout Attributes
-			const Font& getFont() { return mFont; }
+			const Font& getFont() const { return mFont; }
 			Layout& setFont( const Font& font ) { mFont = font; return *this; }
 
-			const ci::Color& getColor() { return mColor; }
+			const ci::Color& getColor() const { return mColor; }
 			Layout& setColor( const ci::Color& color ) { mColor = color; }
 
-			const ci::vec2& getSize() { return mSize; }
+			const ci::vec2& getSize() const { return mSize; }
 			Layout& setSize( ci::vec2 size ) { mSize = size; return *this; }
 
 			const ci::vec2 measure();
 
-			const std::vector<ci::Rectf>& getGlyphBoxes() { return mGlyphBoxes; }
+			const std::vector<ci::Rectf>& getGlyphBoxes() const { return mGlyphBoxes; }
 
-			float getLineHeight() { return mLineHeight.getValue( getFont().getSize() ); }
+			float getLineHeight() const { return mLineHeight.getValue( getFont().getSize() ); }
 			Layout& setLineHeight( const float& lineHeight ) { mLineHeight = txt::Unit( lineHeight ); return *this; };
 			Layout& setLineHeight( const Unit& lineHeight ) { mLineHeight = lineHeight; return *this; };
 
-			float getTracking() { return mTracking.getValue( getFont().getSize() ); }
+			float getTracking() const { return mTracking.getValue( getFont().getSize() ); }
 			Layout& setTracking( float tracking ) { mTracking = txt::Unit( tracking ); return *this; };
 			Layout& setTracking( const Unit& tracking ) { mTracking = tracking; return *this; };
 
-			std::string getLanguage() { return mLanguage; }
+			std::string getLanguage() const { return mLanguage; }
 			Layout& setLanguage( std::string language ) { mLanguage = language; return *this; }
 
-			hb_script_t getScript() { return mScript; }
+			hb_script_t getScript() const { return mScript; }
 			Layout& setScript( hb_script_t script ) { mScript = script; return *this; }
 
-			hb_direction_t getDirection() { return mDirection; }
+			hb_direction_t getDirection() const { return mDirection; }
 			Layout& setDirection( hb_direction_t direction )
 			{
 				mDirection = direction;
@@ -111,7 +111,7 @@ namespace txt
 				return *this;
 			}
 
-			const Alignment& getAlignment() { return mAlignment; }
+			const Alignment& getAlignment() const { return mAlignment; }
 			Layout& setAlignment( Alignment alignment )
 			{
 				mAlignment = alignment;

--- a/src/txt/TextUnits.h
+++ b/src/txt/TextUnits.h
@@ -16,7 +16,9 @@ namespace txt
 		public:
 			Unit() :
 				mType( UnitType::PX ),
-				mIsDefault( true ) {}
+				mIsDefault( true ),
+				mValue( 0 )
+			{}
 
 			Unit( float value, UnitType type = UnitType::PX )
 			{

--- a/src/txt/gl/TextureRenderer.cpp
+++ b/src/txt/gl/TextureRenderer.cpp
@@ -100,7 +100,6 @@ namespace txt
 				texFormat.setMinFilter( GL_LINEAR );
 				//fboFormat.setColorTextureFormat( ci::gl::Texture2d::Format().internalFormat( GL_RGBA32F ) );
 				fboFormat.setColorTextureFormat( texFormat );
-				fboFormat.setSamples( 1 );
 
 				mFbo = ci::gl::Fbo::create( fboSize, fboSize, fboFormat );
 			}


### PR DESCRIPTION
- fixed a crash when using `GROW` for TextBox height
- fixed a problem where `Fbo` wasn't getting resolved (removed `fboFormat.setSamples( 1 )`)
- added some `TextBox` getters
- const correctness for `TextBox` and `TextLayout`